### PR TITLE
changed image pull registry to be the correct one

### DIFF
--- a/kubernetes/cc-frontend-deployment.yml
+++ b/kubernetes/cc-frontend-deployment.yml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: cc-frontend
-        image: docker.pkg.github.com/andreasjohansson1990/cccatalog-frontend/cccatalog-frontend-web:0.1
+        image: docker.pkg.github.com/611-ci-project/cccatalog-frontend/cccatalog
         command: ["npm"]
         args: ["start"]
         ports:


### PR DESCRIPTION
Our deployment manifest pulled its image from our old working repo registry, updated  
the manifest to pull from current working repo registry.