### PR TITLE
feat(helm): add application helm charts

### DIFF
--- a/cc-chart/.helmignore
+++ b/cc-chart/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/cc-chart/Chart.yaml
+++ b/cc-chart/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: cc-chart
+description: A Helm chart for CC-catalog
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0

--- a/cc-chart/templates/_helpers.tpl
+++ b/cc-chart/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cc-chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cc-chart.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cc-chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "cc-chart.labels" -}}
+helm.sh/chart: {{ include "cc-chart.chart" . }}
+{{ include "cc-chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cc-chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cc-chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cc-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cc-chart.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/cc-chart/templates/application.yaml
+++ b/cc-chart/templates/application.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "cc-chart.fullname" . }}-deployment
+  labels:
+    app: {{ template "cc-chart.fullname" . }}-cc-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "cc-chart.fullname" . }}-cc-frontend
+  template:
+    metadata:
+      labels:
+        app: {{ template "cc-chart.fullname" . }}-cc-frontend
+    spec:
+      containers:
+      - name: cc-frontend
+        image: docker.pkg.github.com/611-ci-project/cccatalog-frontend/cccatalog
+        command: ["npm"]
+        args: ["start"]
+        ports:
+        - containerPort: 8443
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cc-chart.fullname" . }}-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: {{ template "cc-chart.fullname" . }}-cc-frontend
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 8443


### PR DESCRIPTION
### Helm integration draft.
Helm packages services and deployments into one singe installation file. Which allows a full stack of applications and services to be deployed to a cluster as one with a single command.

---

### TODO:
#### Implementation:
- [ ] Choose application label names
- [ ] Integrate into production stage deployment
- [ ] Rollback handling

#### Docs:
- [ ] Helm, setup instructions
- [ ] Helm, usage instructions

---

### Test current draft
1. Install helm, _note: system specific_
2. `cd cc-chart/`
3. `helm template .`, _Check what's being deployed to the cluster_
4. `helm install . -g`, _Deploy service and deployment to the cluster with a generated name._
5. `helm uninstall <generated-name>`, _Delete service and deployment with a name._